### PR TITLE
fix gradle 5 incompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,6 @@ buildDeb.dependsOn shadowDistZip
 buildRpm.dependsOn shadowDistZip
 assemble.dependsOn buildRpm, buildDeb
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.7'
 }

--- a/src/main/resources/templates/java-plugin/logfilter/build.gradle.template
+++ b/src/main/resources/templates/java-plugin/logfilter/build.gradle.template
@@ -37,6 +37,6 @@ jar {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.4.1'
 }

--- a/src/main/resources/templates/java-plugin/nodeexecutor/build.gradle.template
+++ b/src/main/resources/templates/java-plugin/nodeexecutor/build.gradle.template
@@ -39,6 +39,6 @@ jar {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.4.1'
 }

--- a/src/main/resources/templates/java-plugin/notification/build.gradle.template
+++ b/src/main/resources/templates/java-plugin/notification/build.gradle.template
@@ -37,6 +37,6 @@ jar {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.4.1'
 }

--- a/src/main/resources/templates/java-plugin/resourcemodelsource/build.gradle.template
+++ b/src/main/resources/templates/java-plugin/resourcemodelsource/build.gradle.template
@@ -36,6 +36,6 @@ jar {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.4.1'
 }

--- a/src/main/resources/templates/java-plugin/workflownodestep/build.gradle.template
+++ b/src/main/resources/templates/java-plugin/workflownodestep/build.gradle.template
@@ -37,6 +37,6 @@ jar {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.4.1'
 }

--- a/src/main/resources/templates/java-plugin/workflowstep/build.gradle.template
+++ b/src/main/resources/templates/java-plugin/workflowstep/build.gradle.template
@@ -37,6 +37,6 @@ jar {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.4.1'
 }


### PR DESCRIPTION
Running `gradle wrapper` on a bootstrapped project gives an error with gradle 5:

```
Cannot add task 'wrapper' as a task with that name already exists.
```

This change fixes that error while still working for gradle 4.
